### PR TITLE
2 GET One Market

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ gem "bootsnap", require: false
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 # gem "rack-cors"
+gem "jsonapi-serializer"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,6 +94,8 @@ GEM
     irb (1.10.0)
       rdoc
       reline (>= 0.3.8)
+    jsonapi-serializer (2.2.0)
+      activesupport (>= 4.2)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -207,6 +209,7 @@ DEPENDENCIES
   debug
   factory_bot_rails
   faker
+  jsonapi-serializer
   pg (~> 1.1)
   pry
   puma (~> 5.0)

--- a/app/controllers/api/v0/markets_controller.rb
+++ b/app/controllers/api/v0/markets_controller.rb
@@ -1,4 +1,6 @@
 class Api::V0::MarketsController < ApplicationController
+  rescue_from ActiveRecord::RecordNotFound, with: :not_found_response
+  
   def index
     markets = Market.all
     render json: MarketSerializer.new(markets)
@@ -7,5 +9,12 @@ class Api::V0::MarketsController < ApplicationController
   def show
     market = Market.find(params[:id])
     render json: MarketSerializer.new(market)
+  end
+
+  private
+ 
+  def not_found_response(exception)
+    render json: ErrorSerializer.new(ErrorMessage.new(exception.message, 404))
+      .serialize_json, status: :not_found
   end
 end

--- a/app/controllers/api/v0/markets_controller.rb
+++ b/app/controllers/api/v0/markets_controller.rb
@@ -1,6 +1,11 @@
 class Api::V0::MarketsController < ApplicationController
   def index
     markets = Market.all
-    render json: MarketSerializer.format_markets(markets)
+    render json: MarketSerializer.new(markets)
+  end
+
+  def show
+    market = Market.find(params[:id])
+    render json: MarketSerializer.new(market)
   end
 end

--- a/app/models/market.rb
+++ b/app/models/market.rb
@@ -7,5 +7,4 @@ class Market < ApplicationRecord
   def get_vendor_count
     self.vendors.count
   end
- 
 end

--- a/app/models/market_vendor.rb
+++ b/app/models/market_vendor.rb
@@ -2,5 +2,5 @@ class MarketVendor < ApplicationRecord
   belongs_to :market
   belongs_to :vendor
 
-  # validates :market, :vendor, presence: true
+  validates :market, :vendor, presence: true
 end

--- a/app/poros/error_message.rb
+++ b/app/poros/error_message.rb
@@ -1,0 +1,8 @@
+class ErrorMessage
+  attr_reader :message, :status_code
+
+  def initialize(message, status_code)
+    @message = message
+    @status_code = status_code
+  end
+end

--- a/app/serializers/error_serializer.rb
+++ b/app/serializers/error_serializer.rb
@@ -1,0 +1,16 @@
+class ErrorSerializer
+  def initialize(error_object)
+    @error_object = error_object
+  end
+
+  def serialize_json
+    {
+      errors: [
+        {
+          status: @error_object.status_code.to_s,
+          title: @error_object.message
+        }
+      ]
+    }
+  end
+end

--- a/app/serializers/market_serializer.rb
+++ b/app/serializers/market_serializer.rb
@@ -1,23 +1,36 @@
 class MarketSerializer
-  def self.format_markets(markets)
-    {
-      data: markets.map do |market|
-        {
-          id: market.id,
-          type: 'market',
-          attributes: {
-            name: market.name,
-            street: market.street,
-            city: market.city,
-            county: market.county,
-            state: market.state,
-            zip: market.zip,
-            lat: market.lat,
-            lon: market.lon,
-            vendor_count: market.get_vendor_count
-          }
-        }
-      end
-    }
+  include JSONAPI::Serializer
+  attributes :name, :street, :city, :county, :state, :zip, :lat, :lon
+
+  has_many :market_vendors
+  has_many :vendors, through: :market_vendors
+
+  attribute :vendor_count do |object|
+    object.get_vendor_count
   end
+
+  # def self.format_markets(markets)
+  #   {
+  #     data: markets.map do |market|
+  #       {
+  #         id: market.id,
+  #         type: 'market',
+  #         attributes: {
+  #           name: market.name,
+  #           street: market.street,
+  #           city: market.city,
+  #           county: market.county,
+  #           state: market.state,
+  #           zip: market.zip,
+  #           lat: market.lat,
+  #           lon: market.lon,
+  #           vendor_count: market.get_vendor_count
+  #         }
+          # relationships: {
+            # market.vendors...
+          # }
+  #       }
+  #     end
+  #   }
+  # end
 end

--- a/app/serializers/market_vendor_serializer.rb
+++ b/app/serializers/market_vendor_serializer.rb
@@ -1,0 +1,7 @@
+class MarketVendorSerializer
+  include JSONAPI::Serializer
+  attributes :market_id, :vendor_id
+
+  belongs_to :market
+  belongs_to :vendor
+end

--- a/app/serializers/vendor_serializer.rb
+++ b/app/serializers/vendor_serializer.rb
@@ -1,0 +1,7 @@
+class VendorSerializer
+  include JSONAPI::Serializer
+  attributes :name, :description, :contact_name, :contact_phone
+
+  has_many :market_vendors
+  has_many :markets, through: :market_vendors
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,9 @@ Rails.application.routes.draw do
     namespace :api do
       namespace :v0 do
         # get '/markets', to: 'markets#index'
-        resources :markets, only: [:index, :show]
+        resources :markets, only: [:index, :show] do
+          # resources :vendors, only: [:index], controller: 'market_vendors'
+        end
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
     namespace :api do
       namespace :v0 do
         # get '/markets', to: 'markets#index'
-        resources :markets, only: [:index]
+        resources :markets, only: [:index, :show]
       end
     end
   end

--- a/spec/models/market_spec.rb
+++ b/spec/models/market_spec.rb
@@ -19,15 +19,14 @@ RSpec.describe Market, type: :model do
   describe '#Instance Methods' do
     it '#get_vendor_count' do
       market = create(:market)
-      expect(market.send(:get_vendor_count)).to eq(0)
+      expect(market.get_vendor_count).to eq(0)
+
       vendor = create(:vendor)
-      market.vendors << vendor
-      # QUESTION: I tried and did not work... create_list(:vendor, 3, markets: market)
+      market.vendors << vendor # QUESTION: I tried and did not work... create_list(:vendor, 3, markets: market)
       expect(market.get_vendor_count).to eq(1)
 
       more_vendors = create_list(:vendor, 2)
       market.vendors << more_vendors
-
       expect(market.get_vendor_count).to eq(3)
     end
   end

--- a/spec/models/market_vendor_spec.rb
+++ b/spec/models/market_vendor_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe MarketVendor, type: :model do
     it { should belong_to(:market) }
     it { should belong_to(:vendor) }
   
-    # it { should validate_presence_of(:market) }
-    # it { should validate_presence_of(:vendor) }
+    it { should validate_presence_of(:market) }
+    it { should validate_presence_of(:vendor) }
   end
 end

--- a/spec/requests/api/v0/markets_request_spec.rb
+++ b/spec/requests/api/v0/markets_request_spec.rb
@@ -1,20 +1,19 @@
 require 'rails_helper'
 
 describe 'Markets API' do
-  before(:each) do
+  it 'sends a list of all markets, get all markets, index - /api/v0/markets' do
     market_1 = create(:market, vendors: [create(:vendor)])
     market_2 = create(:market, vendors: create_list(:vendor, 2))
     market_3 = create(:market)
-    @markets = [market_1, market_2, market_3]
-  end
+    # markets_list = [market_1, market_2, market_3]
 
-  it 'sends a list of all markets, get all markets, index' do
     get '/api/v0/markets'
     expect(response).to be_successful
-    @markets = JSON.parse(response.body, symbolize_names: true)
-    expect(@markets[:data].count).to eq(3)
+    
+    markets_parsed = JSON.parse(response.body, symbolize_names: true)
+    expect(markets_parsed[:data].count).to eq(3)
 
-    @markets[:data].each do |market|
+    markets_parsed[:data].each do |market|
       expect(market).to have_key(:id)
       expect(market[:id]).to be_an(Integer)
 
@@ -51,5 +50,13 @@ describe 'Markets API' do
       expect(attributes).to have_key(:vendor_count)
       expect(attributes[:vendor_count]).to be_an(Integer)
     end
+  end
+
+  it 'gets a single market, by its id, show - /api/v0/markets/:id' do
+    market = create(:market)
+    get "/api/v0/markets/#{market.id}"
+    expect(response).to be_successful
+
+    # market_parsed = JSON.parse(response.body, symbolize_names: true)
   end
 end

--- a/spec/requests/api/v0/markets_request_spec.rb
+++ b/spec/requests/api/v0/markets_request_spec.rb
@@ -15,7 +15,7 @@ describe 'Markets API' do
 
     markets_parsed[:data].each do |market|
       expect(market).to have_key(:id)
-      expect(market[:id]).to be_an(Integer)
+      expect(market[:id]).to be_an(String)
 
       expect(market).to have_key(:type)
       expect(market[:type]).to be_an(String)

--- a/spec/requests/api/v0/markets_request_spec.rb
+++ b/spec/requests/api/v0/markets_request_spec.rb
@@ -57,6 +57,48 @@ describe 'Markets API' do
     get "/api/v0/markets/#{market.id}"
     expect(response).to be_successful
 
-    # market_parsed = JSON.parse(response.body, symbolize_names: true)
+    market_parsed = JSON.parse(response.body, symbolize_names: true)
+
+    attributes = market_parsed[:data][:attributes]
+
+    expect(attributes).to have_key(:name)
+    expect(attributes[:name]).to be_an(String)
+
+    expect(attributes).to have_key(:street)
+    expect(attributes[:street]).to be_an(String)
+
+    expect(attributes).to have_key(:city)
+    expect(attributes[:city]).to be_an(String)
+
+    expect(attributes).to have_key(:county)
+    expect(attributes[:county]).to be_an(String)
+
+    expect(attributes).to have_key(:state)
+    expect(attributes[:state]).to be_an(String)
+
+    expect(attributes).to have_key(:zip)
+    expect(attributes[:zip]).to be_an(String)
+
+    expect(attributes).to have_key(:lat)
+    expect(attributes[:lat]).to be_an(String)
+
+    expect(attributes).to have_key(:lon)
+    expect(attributes[:lon]).to be_an(String)
+
+    expect(attributes).to have_key(:vendor_count)
+    expect(attributes[:vendor_count]).to be_an(Integer)
   end
+
+  it 'gets a single market, by its BAD id, show - /api/v0/markets/:id, SAD path' do
+    get "/api/v0/markets/1"
+    expect(response).to_not be_successful
+    expect(response.status).to eq(404)
+
+    data = JSON.parse(response.body, symbolize_names: true)
+    
+    expect(data[:errors]).to be_a(Array)
+    expect(data[:errors].first[:status]).to eq("404")
+    expect(data[:errors].first[:title]).to eq("Couldn't find Market with 'id'=1")
+  end
+
 end

--- a/spec/serializers/market_serializer_spec.rb
+++ b/spec/serializers/market_serializer_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe MarketSerializer, type: :request do
+  describe 'Serializing' do
+    it 'has keys and data with types' do
+      create_list(:market, 5)
+      get '/api/v0/markets'
+      expect(response).to be_successful
+
+      data = JSON.parse(response.body)
+      market = data["data"].first["attributes"]
+
+      expect(market).to have_key("name")
+      expect(market["name"]).to be_an(String)
+
+      expect(market).to have_key("street")
+      expect(market["street"]).to be_an(String)
+
+      expect(market).to have_key("city")
+      expect(market["city"]).to be_an(String)
+
+      expect(market).to have_key("county")
+      expect(market["county"]).to be_an(String)
+
+      expect(market).to have_key("state")
+      expect(market["state"]).to be_an(String)
+
+      expect(market).to have_key("zip")
+      expect(market["zip"]).to be_an(String)
+
+      expect(market).to have_key("lat")
+      expect(market["lat"]).to be_an(String)
+
+      expect(market).to have_key("lon")
+      expect(market["lon"]).to be_an(String)
+
+      expect(market).to have_key("vendor_count")
+      expect(market["vendor_count"]).to be_an(Integer)
+    end
+  end
+end


### PR DESCRIPTION
Add endpoint for `GET /api/v0/markets/:id`

1. This endpoint should follow the pattern of GET /api/v0/markets/:id.
2. f a valid market id is passed in, all market attributes, as well as a vendor_count should be returned.
3. If an invalid market id is passed in, a 404 status as well as a descriptive error message should be sent back in the response.

Notes
added in error functionality too