### PR TITLE
3 GET All Market Vendors

### DIFF
--- a/app/controllers/api/v0/market_vendors_controller.rb
+++ b/app/controllers/api/v0/market_vendors_controller.rb
@@ -1,7 +1,16 @@
 class Api::V0::MarketVendorsController < ApplicationController
+  rescue_from ActiveRecord::RecordNotFound, with: :not_found_response
+
   def index
     market = Market.find(params[:market_id])
     vendors = market.vendors
     render json: VendorSerializer.new(vendors)
+  end
+
+  private
+ 
+  def not_found_response(exception)
+    render json: ErrorSerializer.new(ErrorMessage.new(exception.message, 404))
+      .serialize_json, status: :not_found
   end
 end

--- a/app/controllers/api/v0/market_vendors_controller.rb
+++ b/app/controllers/api/v0/market_vendors_controller.rb
@@ -1,0 +1,5 @@
+class Api::V0::MarketVendorssController < ApplicationController
+  def index
+    
+  end
+end

--- a/app/controllers/api/v0/market_vendors_controller.rb
+++ b/app/controllers/api/v0/market_vendors_controller.rb
@@ -1,5 +1,7 @@
-class Api::V0::MarketVendorssController < ApplicationController
+class Api::V0::MarketVendorsController < ApplicationController
   def index
-    
+    market = Market.find(params[:market_id])
+    vendors = market.vendors
+    render json: VendorSerializer.new(vendors)
   end
 end

--- a/app/serializers/vendor_serializer.rb
+++ b/app/serializers/vendor_serializer.rb
@@ -1,6 +1,6 @@
 class VendorSerializer
   include JSONAPI::Serializer
-  attributes :name, :description, :contact_name, :contact_phone
+  attributes :name, :description, :contact_name, :contact_phone, :credit_accepted
 
   has_many :market_vendors
   has_many :markets, through: :market_vendors

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,9 +7,8 @@ Rails.application.routes.draw do
   Rails.application.routes.draw do
     namespace :api do
       namespace :v0 do
-        # get '/markets', to: 'markets#index'
         resources :markets, only: [:index, :show] do
-          # resources :vendors, only: [:index], controller: 'market_vendors'
+          resources :vendors, only: [:index], controller: 'market_vendors'
         end
       end
     end

--- a/spec/requests/api/v0/market_vendors_request_spec.rb
+++ b/spec/requests/api/v0/market_vendors_request_spec.rb
@@ -11,9 +11,10 @@ describe 'Markets API' do
     expect(response).to be_successful
 
     vendors_parsed = JSON.parse(response.body, symbolize_names: true)
-    expect(markets_parsed[:data].count).to eq(5)
+    vendor_data = vendors_parsed[:data]
+    expect(vendor_data.count).to eq(5)
 
-    vendors_parsed.each do |vendor|
+    vendor_data.each do |vendor|
       expect(vendor).to have_key(:id)
       expect(vendor[:id]).to be_an(String)
 
@@ -36,7 +37,7 @@ describe 'Markets API' do
       expect(attributes[:contact_phone]).to be_an(String)
 
       expect(attributes).to have_key(:credit_accepted)
-      expect(attributes[:credit_accepted]).to be_an(Boolean)
+      expect(attributes[:credit_accepted]).to be_a(TrueClass).or be_a(FalseClass)
     end
   end
 end

--- a/spec/requests/api/v0/market_vendors_request_spec.rb
+++ b/spec/requests/api/v0/market_vendors_request_spec.rb
@@ -40,4 +40,17 @@ describe 'Markets API' do
       expect(attributes[:credit_accepted]).to be_a(TrueClass).or be_a(FalseClass)
     end
   end
+
+  it 'gets a single market vendors, by its BAD id, index - /api/v0/markets/:id/vendors, SAD path' do
+    get "/api/v0/markets/1/vendors"
+    expect(response).to_not be_successful
+    expect(response.status).to eq(404)
+
+    data = JSON.parse(response.body, symbolize_names: true)
+    
+    expect(data[:errors]).to be_a(Array)
+    expect(data[:errors].first[:status]).to eq("404")
+    expect(data[:errors].first[:title]).to eq("Couldn't find Market with 'id'=1")
+  end
+  
 end

--- a/spec/requests/api/v0/market_vendors_request_spec.rb
+++ b/spec/requests/api/v0/market_vendors_request_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+describe 'Markets API' do
+  it 'sends a list of all vendors for a market, get all vendors, index - /api/v0/markets/:id/vendors' do
+    vendors = create_list(:vendor, 5)
+    market = create(:market, vendors: vendors)
+    vendors_2 = create_list(:vendor, 5)
+    market_2 = create(:market, vendors: vendors_2)
+
+    get "/api/v0/markets/#{market.id}/vendors"
+    expect(response).to be_successful
+
+    vendors_parsed = JSON.parse(response.body, symbolize_names: true)
+    expect(markets_parsed[:data].count).to eq(5)
+
+    vendors_parsed.each do |vendor|
+      expect(vendor).to have_key(:id)
+      expect(vendor[:id]).to be_an(String)
+
+      expect(vendor).to have_key(:type)
+      expect(vendor[:type]).to be_an(String)
+      expect(vendor[:type]).to eq('vendor')
+
+      attributes = vendor[:attributes]
+
+      expect(attributes).to have_key(:name)
+      expect(attributes[:name]).to be_an(String)
+      
+      expect(attributes).to have_key(:description)
+      expect(attributes[:description]).to be_an(String)
+
+      expect(attributes).to have_key(:contact_name)
+      expect(attributes[:contact_name]).to be_an(String)
+
+      expect(attributes).to have_key(:contact_phone)
+      expect(attributes[:contact_phone]).to be_an(String)
+
+      expect(attributes).to have_key(:credit_accepted)
+      expect(attributes[:credit_accepted]).to be_an(Boolean)
+    end
+  end
+end

--- a/spec/serializers/vendor_serializer_spec.rb
+++ b/spec/serializers/vendor_serializer_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe MarketSerializer, type: :request do
+  describe 'Serializing' do
+    it 'has keys and data with types' do
+      create_list(:market, 5)
+      get '/api/v0/markets'
+      expect(response).to be_successful
+
+      data = JSON.parse(response.body)
+      market = data["data"].first["attributes"]
+
+      expect(market).to have_key("name")
+      expect(market["name"]).to be_an(String)
+
+      expect(market).to have_key("street")
+      expect(market["street"]).to be_an(String)
+
+      expect(market).to have_key("city")
+      expect(market["city"]).to be_an(String)
+
+      expect(market).to have_key("county")
+      expect(market["county"]).to be_an(String)
+
+      expect(market).to have_key("state")
+      expect(market["state"]).to be_an(String)
+
+      expect(market).to have_key("zip")
+      expect(market["zip"]).to be_an(String)
+
+      expect(market).to have_key("lat")
+      expect(market["lat"]).to be_an(String)
+
+      expect(market).to have_key("lon")
+      expect(market["lon"]).to be_an(String)
+
+      expect(market).to have_key("vendor_count")
+      expect(market["vendor_count"]).to be_an(Integer)
+    end
+  end
+end

--- a/spec/serializers/vendor_serializer_spec.rb
+++ b/spec/serializers/vendor_serializer_spec.rb
@@ -1,41 +1,30 @@
 require 'rails_helper'
 
-RSpec.describe MarketSerializer, type: :request do
+RSpec.describe VendorSerializer, type: :request do
   describe 'Serializing' do
     it 'has keys and data with types' do
-      create_list(:market, 5)
-      get '/api/v0/markets'
+      vendors = create_list(:vendor, 5)
+      market = create(:market, vendors: vendors)
+      get "/api/v0/markets/#{market.id}/vendors"
       expect(response).to be_successful
 
       data = JSON.parse(response.body)
-      market = data["data"].first["attributes"]
+      vendor = data["data"].first["attributes"]
 
-      expect(market).to have_key("name")
-      expect(market["name"]).to be_an(String)
+      expect(vendor).to have_key("name")
+      expect(vendor["name"]).to be_an(String)
 
-      expect(market).to have_key("street")
-      expect(market["street"]).to be_an(String)
+      expect(vendor).to have_key("description")
+      expect(vendor["description"]).to be_an(String)
 
-      expect(market).to have_key("city")
-      expect(market["city"]).to be_an(String)
+      expect(vendor).to have_key("contact_name")
+      expect(vendor["contact_name"]).to be_an(String)
 
-      expect(market).to have_key("county")
-      expect(market["county"]).to be_an(String)
+      expect(vendor).to have_key("contact_phone")
+      expect(vendor["contact_phone"]).to be_an(String)
 
-      expect(market).to have_key("state")
-      expect(market["state"]).to be_an(String)
-
-      expect(market).to have_key("zip")
-      expect(market["zip"]).to be_an(String)
-
-      expect(market).to have_key("lat")
-      expect(market["lat"]).to be_an(String)
-
-      expect(market).to have_key("lon")
-      expect(market["lon"]).to be_an(String)
-
-      expect(market).to have_key("vendor_count")
-      expect(market["vendor_count"]).to be_an(Integer)
+      expect(vendor).to have_key("credit_accepted")
+      expect(vendor["credit_accepted"]).to be_a(TrueClass).or be_a(FalseClass)
     end
   end
 end


### PR DESCRIPTION
Add endpoint `/api/v0/markets/:id/vendors`

1. This endpoint should follow the pattern of GET /api/v0/markets/:id/vendors
2. If a valid market id is passed in, a JSON object is sent back with a top-level data key that points to a collection of that market’s vendors. Each vendor contains all of it’s attributes.
3. If an invalid market id is passed in, a 404 status as well as a descriptive error message should be sent back in the response.