### PR TITLE
4 GET One Vendor

### DIFF
--- a/app/controllers/api/v0/vendors_controller.rb
+++ b/app/controllers/api/v0/vendors_controller.rb
@@ -1,0 +1,15 @@
+class Api::V0::VendorsController < ApplicationController
+  rescue_from ActiveRecord::RecordNotFound, with: :not_found_response
+  
+  def show
+    vendor = Vendor.find(params[:id])
+    render json: VendorSerializer.new(vendor)
+  end
+
+  private
+ 
+  def not_found_response(exception)
+    render json: ErrorSerializer.new(ErrorMessage.new(exception.message, 404))
+      .serialize_json, status: :not_found
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,8 @@ Rails.application.routes.draw do
         resources :markets, only: [:index, :show] do
           resources :vendors, only: [:index], controller: 'market_vendors'
         end
+
+        resources :vendors, only: [:show]
       end
     end
   end

--- a/spec/requests/api/v0/market_vendors_request_spec.rb
+++ b/spec/requests/api/v0/market_vendors_request_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe 'Markets API' do
+describe 'Market Vendors API' do
   it 'sends a list of all vendors for a market, get all vendors, index - /api/v0/markets/:id/vendors' do
     vendors = create_list(:vendor, 5)
     market = create(:market, vendors: vendors)

--- a/spec/requests/api/v0/vendors_request_spec.rb
+++ b/spec/requests/api/v0/vendors_request_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+describe 'Vendors API' do
+  it 'gets a single vendor, by its id, show - /api/v0/vendors/:id' do
+    vendor = create(:vendor)
+    get "/api/v0/vendors/#{vendor.id}"
+    expect(response).to be_successful
+
+    vendor_parsed = JSON.parse(response.body, symbolize_names: true)
+
+    attributes = vendor_parsed[:data][:attributes]
+
+    expect(attributes).to have_key(:name)
+    expect(attributes[:name]).to be_an(String)
+    
+    expect(attributes).to have_key(:description)
+    expect(attributes[:description]).to be_an(String)
+
+    expect(attributes).to have_key(:contact_name)
+    expect(attributes[:contact_name]).to be_an(String)
+
+    expect(attributes).to have_key(:contact_phone)
+    expect(attributes[:contact_phone]).to be_an(String)
+
+    expect(attributes).to have_key(:credit_accepted)
+    expect(attributes[:credit_accepted]).to be_a(TrueClass).or be_a(FalseClass)
+   
+  end
+
+  it 'gets a single vendor, by its BAD id, show - /api/v0/vendors/:id, SAD path' do
+    get "/api/v0/vendors/1"
+    expect(response).to_not be_successful
+    expect(response.status).to eq(404)
+
+    data = JSON.parse(response.body, symbolize_names: true)
+    
+    expect(data[:errors]).to be_a(Array)
+    expect(data[:errors].first[:status]).to eq("404")
+    expect(data[:errors].first[:title]).to eq("Couldn't find Vendor with 'id'=1")
+  end
+
+end


### PR DESCRIPTION
Add endpoint `GET /api/v0/vendors/:id`

1. This endpoint should follow the pattern of GET /api/v0/vendors/:id
2. If a valid vendor id is passed in, a JSON object is sent back with a top-level data key that points to the vendor resource with that id, and all attributes for that vendor.
3. If an invalid vendor id is passed in, a 404 status as well as a descriptive error message should be sent back in the response.