### PR TITLE
6 UPDATE Vendor

### DIFF
--- a/app/controllers/api/v0/vendors_controller.rb
+++ b/app/controllers/api/v0/vendors_controller.rb
@@ -12,6 +12,12 @@ class Api::V0::VendorsController < ApplicationController
     render json: VendorSerializer.new(vendor), status: 201
   end
 
+  def update
+    vendor = Vendor.find(params[:id])
+    vendor.update!(vendor_params)
+    render json: VendorSerializer.new(vendor), status: 200
+  end
+
   def destroy
     vendor = Vendor.find(params[:id])
     vendor.destroy
@@ -31,6 +37,11 @@ class Api::V0::VendorsController < ApplicationController
   end
 
   def vendor_params
+    params.require(:vendor).permit(:name, :description, :contact_name, :contact_phone, :credit_accepted)
+  end
+
+  # Here to jsut test if require matters or not
+  def vendor_params_update
     params.require(:vendor).permit(:name, :description, :contact_name, :contact_phone, :credit_accepted)
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
           resources :vendors, only: [:index], controller: 'market_vendors'
         end
 
-        resources :vendors, only: [:show, :create, :destroy]
+        resources :vendors, only: [:show, :create, :update, :destroy]
       end
     end
   end

--- a/spec/requests/api/v0/market_vendors_request_spec.rb
+++ b/spec/requests/api/v0/market_vendors_request_spec.rb
@@ -1,56 +1,57 @@
 require 'rails_helper'
 
-describe 'Market Vendors API' do
-  it 'sends a list of all vendors for a market, get all vendors, index - /api/v0/markets/:id/vendors' do
-    vendors = create_list(:vendor, 5)
-    market = create(:market, vendors: vendors)
-    vendors_2 = create_list(:vendor, 5)
-    market_2 = create(:market, vendors: vendors_2)
+describe 'Market Vendors API', type: :request do
+  describe 'Get All Vendors for a Market' do
+    it 'sends a list of all vendors for a market, get all vendors, index - /api/v0/markets/:id/vendors' do
+      vendors = create_list(:vendor, 5)
+      market = create(:market, vendors: vendors)
+      vendors_2 = create_list(:vendor, 5)
+      market_2 = create(:market, vendors: vendors_2)
 
-    get "/api/v0/markets/#{market.id}/vendors"
-    expect(response).to be_successful
+      get "/api/v0/markets/#{market.id}/vendors"
+      expect(response).to be_successful
 
-    vendors_parsed = JSON.parse(response.body, symbolize_names: true)
-    vendor_data = vendors_parsed[:data]
-    expect(vendor_data.count).to eq(5)
+      vendors_parsed = JSON.parse(response.body, symbolize_names: true)
+      vendor_data = vendors_parsed[:data]
+      expect(vendor_data.count).to eq(5)
 
-    vendor_data.each do |vendor|
-      expect(vendor).to have_key(:id)
-      expect(vendor[:id]).to be_an(String)
+      vendor_data.each do |vendor|
+        expect(vendor).to have_key(:id)
+        expect(vendor[:id]).to be_an(String)
 
-      expect(vendor).to have_key(:type)
-      expect(vendor[:type]).to be_an(String)
-      expect(vendor[:type]).to eq('vendor')
+        expect(vendor).to have_key(:type)
+        expect(vendor[:type]).to be_an(String)
+        expect(vendor[:type]).to eq('vendor')
 
-      attributes = vendor[:attributes]
+        attributes = vendor[:attributes]
 
-      expect(attributes).to have_key(:name)
-      expect(attributes[:name]).to be_an(String)
+        expect(attributes).to have_key(:name)
+        expect(attributes[:name]).to be_an(String)
+        
+        expect(attributes).to have_key(:description)
+        expect(attributes[:description]).to be_an(String)
+
+        expect(attributes).to have_key(:contact_name)
+        expect(attributes[:contact_name]).to be_an(String)
+
+        expect(attributes).to have_key(:contact_phone)
+        expect(attributes[:contact_phone]).to be_an(String)
+
+        expect(attributes).to have_key(:credit_accepted)
+        expect(attributes[:credit_accepted]).to be_a(TrueClass).or be_a(FalseClass)
+      end
+    end
+
+    it 'gets a single market vendors, by its BAD id, index - /api/v0/markets/:id/vendors, SAD path' do
+      get "/api/v0/markets/1/vendors"
+      expect(response).to_not be_successful
+      expect(response.status).to eq(404)
+
+      data = JSON.parse(response.body, symbolize_names: true)
       
-      expect(attributes).to have_key(:description)
-      expect(attributes[:description]).to be_an(String)
-
-      expect(attributes).to have_key(:contact_name)
-      expect(attributes[:contact_name]).to be_an(String)
-
-      expect(attributes).to have_key(:contact_phone)
-      expect(attributes[:contact_phone]).to be_an(String)
-
-      expect(attributes).to have_key(:credit_accepted)
-      expect(attributes[:credit_accepted]).to be_a(TrueClass).or be_a(FalseClass)
+      expect(data[:errors]).to be_a(Array)
+      expect(data[:errors].first[:status]).to eq("404")
+      expect(data[:errors].first[:title]).to eq("Couldn't find Market with 'id'=1")
     end
   end
-
-  it 'gets a single market vendors, by its BAD id, index - /api/v0/markets/:id/vendors, SAD path' do
-    get "/api/v0/markets/1/vendors"
-    expect(response).to_not be_successful
-    expect(response.status).to eq(404)
-
-    data = JSON.parse(response.body, symbolize_names: true)
-    
-    expect(data[:errors]).to be_a(Array)
-    expect(data[:errors].first[:status]).to eq("404")
-    expect(data[:errors].first[:title]).to eq("Couldn't find Market with 'id'=1")
-  end
-  
 end

--- a/spec/requests/api/v0/markets_request_spec.rb
+++ b/spec/requests/api/v0/markets_request_spec.rb
@@ -1,27 +1,68 @@
 require 'rails_helper'
 
-describe 'Markets API' do
-  it 'sends a list of all markets, get all markets, index - /api/v0/markets' do
-    market_1 = create(:market, vendors: [create(:vendor)])
-    market_2 = create(:market, vendors: create_list(:vendor, 2))
-    market_3 = create(:market)
-    # markets_list = [market_1, market_2, market_3]
+describe 'Markets API', type: :request do
+  describe 'Get All Markets' do
+    it 'sends a list of all markets, get all markets, index - /api/v0/markets' do
+      market_1 = create(:market, vendors: [create(:vendor)])
+      market_2 = create(:market, vendors: create_list(:vendor, 2))
+      market_3 = create(:market)
+      # markets_list = [market_1, market_2, market_3]
 
-    get '/api/v0/markets'
-    expect(response).to be_successful
-    
-    markets_parsed = JSON.parse(response.body, symbolize_names: true)
-    expect(markets_parsed[:data].count).to eq(3)
+      get '/api/v0/markets'
+      expect(response).to be_successful
+      
+      markets_parsed = JSON.parse(response.body, symbolize_names: true)
+      expect(markets_parsed[:data].count).to eq(3)
 
-    markets_parsed[:data].each do |market|
-      expect(market).to have_key(:id)
-      expect(market[:id]).to be_an(String)
+      markets_parsed[:data].each do |market|
+        expect(market).to have_key(:id)
+        expect(market[:id]).to be_an(String)
 
-      expect(market).to have_key(:type)
-      expect(market[:type]).to be_an(String)
-      expect(market[:type]).to eq('market')
+        expect(market).to have_key(:type)
+        expect(market[:type]).to be_an(String)
+        expect(market[:type]).to eq('market')
 
-      attributes = market[:attributes]
+        attributes = market[:attributes]
+
+        expect(attributes).to have_key(:name)
+        expect(attributes[:name]).to be_an(String)
+
+        expect(attributes).to have_key(:street)
+        expect(attributes[:street]).to be_an(String)
+
+        expect(attributes).to have_key(:city)
+        expect(attributes[:city]).to be_an(String)
+
+        expect(attributes).to have_key(:county)
+        expect(attributes[:county]).to be_an(String)
+
+        expect(attributes).to have_key(:state)
+        expect(attributes[:state]).to be_an(String)
+
+        expect(attributes).to have_key(:zip)
+        expect(attributes[:zip]).to be_an(String)
+
+        expect(attributes).to have_key(:lat)
+        expect(attributes[:lat]).to be_an(String)
+
+        expect(attributes).to have_key(:lon)
+        expect(attributes[:lon]).to be_an(String)
+
+        expect(attributes).to have_key(:vendor_count)
+        expect(attributes[:vendor_count]).to be_an(Integer)
+      end
+    end
+  end
+
+  describe 'Get One Market, by id' do
+    it 'gets a single market, by its id, show - /api/v0/markets/:id' do
+      market = create(:market)
+      get "/api/v0/markets/#{market.id}"
+      expect(response).to be_successful
+
+      market_parsed = JSON.parse(response.body, symbolize_names: true)
+
+      attributes = market_parsed[:data][:attributes]
 
       expect(attributes).to have_key(:name)
       expect(attributes[:name]).to be_an(String)
@@ -50,55 +91,17 @@ describe 'Markets API' do
       expect(attributes).to have_key(:vendor_count)
       expect(attributes[:vendor_count]).to be_an(Integer)
     end
+
+    it 'gets a single market, by its BAD id, show - /api/v0/markets/:id, SAD path' do
+      get "/api/v0/markets/1"
+      expect(response).to_not be_successful
+      expect(response.status).to eq(404)
+
+      data = JSON.parse(response.body, symbolize_names: true)
+      
+      expect(data[:errors]).to be_a(Array)
+      expect(data[:errors].first[:status]).to eq("404")
+      expect(data[:errors].first[:title]).to eq("Couldn't find Market with 'id'=1")
+    end
   end
-
-  it 'gets a single market, by its id, show - /api/v0/markets/:id' do
-    market = create(:market)
-    get "/api/v0/markets/#{market.id}"
-    expect(response).to be_successful
-
-    market_parsed = JSON.parse(response.body, symbolize_names: true)
-
-    attributes = market_parsed[:data][:attributes]
-
-    expect(attributes).to have_key(:name)
-    expect(attributes[:name]).to be_an(String)
-
-    expect(attributes).to have_key(:street)
-    expect(attributes[:street]).to be_an(String)
-
-    expect(attributes).to have_key(:city)
-    expect(attributes[:city]).to be_an(String)
-
-    expect(attributes).to have_key(:county)
-    expect(attributes[:county]).to be_an(String)
-
-    expect(attributes).to have_key(:state)
-    expect(attributes[:state]).to be_an(String)
-
-    expect(attributes).to have_key(:zip)
-    expect(attributes[:zip]).to be_an(String)
-
-    expect(attributes).to have_key(:lat)
-    expect(attributes[:lat]).to be_an(String)
-
-    expect(attributes).to have_key(:lon)
-    expect(attributes[:lon]).to be_an(String)
-
-    expect(attributes).to have_key(:vendor_count)
-    expect(attributes[:vendor_count]).to be_an(Integer)
-  end
-
-  it 'gets a single market, by its BAD id, show - /api/v0/markets/:id, SAD path' do
-    get "/api/v0/markets/1"
-    expect(response).to_not be_successful
-    expect(response.status).to eq(404)
-
-    data = JSON.parse(response.body, symbolize_names: true)
-    
-    expect(data[:errors]).to be_a(Array)
-    expect(data[:errors].first[:status]).to eq("404")
-    expect(data[:errors].first[:title]).to eq("Couldn't find Market with 'id'=1")
-  end
-
 end

--- a/spec/requests/api/v0/vendors_request_spec.rb
+++ b/spec/requests/api/v0/vendors_request_spec.rb
@@ -1,181 +1,212 @@
 require 'rails_helper'
 
-describe 'Vendors API' do
-  it 'gets a single vendor, by its id, show - /api/v0/vendors/:id' do
-    vendor = create(:vendor)
-    get "/api/v0/vendors/#{vendor.id}"
-    expect(response).to be_successful
+describe 'Vendors API', type: :request do
+  describe 'Get One Vendor, by id' do
+    it 'gets a single vendor, by its id, show - /api/v0/vendors/:id' do
+      vendor = create(:vendor)
+      get "/api/v0/vendors/#{vendor.id}"
+      expect(response).to be_successful
 
-    vendor_parsed = JSON.parse(response.body, symbolize_names: true)
+      vendor_parsed = JSON.parse(response.body, symbolize_names: true)
 
-    attributes = vendor_parsed[:data][:attributes]
+      attributes = vendor_parsed[:data][:attributes]
 
-    expect(attributes).to have_key(:name)
-    expect(attributes[:name]).to be_an(String)
+      expect(attributes).to have_key(:name)
+      expect(attributes[:name]).to be_an(String)
+      
+      expect(attributes).to have_key(:description)
+      expect(attributes[:description]).to be_an(String)
+
+      expect(attributes).to have_key(:contact_name)
+      expect(attributes[:contact_name]).to be_an(String)
+
+      expect(attributes).to have_key(:contact_phone)
+      expect(attributes[:contact_phone]).to be_an(String)
+
+      expect(attributes).to have_key(:credit_accepted)
+      expect(attributes[:credit_accepted]).to be_a(TrueClass).or be_a(FalseClass)
     
-    expect(attributes).to have_key(:description)
-    expect(attributes[:description]).to be_an(String)
+    end
 
-    expect(attributes).to have_key(:contact_name)
-    expect(attributes[:contact_name]).to be_an(String)
+    it 'gets a single vendor, by its BAD id, show - /api/v0/vendors/:id, SAD path' do
+      get "/api/v0/vendors/1"
+      expect(response).to_not be_successful
+      expect(response.status).to eq(404)
 
-    expect(attributes).to have_key(:contact_phone)
-    expect(attributes[:contact_phone]).to be_an(String)
-
-    expect(attributes).to have_key(:credit_accepted)
-    expect(attributes[:credit_accepted]).to be_a(TrueClass).or be_a(FalseClass)
-   
+      data = JSON.parse(response.body, symbolize_names: true)
+      
+      expect(data[:errors]).to be_a(Array)
+      expect(data[:errors].first[:status]).to eq("404")
+      expect(data[:errors].first[:title]).to eq("Couldn't find Vendor with 'id'=1")
+    end
   end
 
-  it 'gets a single vendor, by its BAD id, show - /api/v0/vendors/:id, SAD path' do
-    get "/api/v0/vendors/1"
-    expect(response).to_not be_successful
-    expect(response.status).to eq(404)
-
-    data = JSON.parse(response.body, symbolize_names: true)
+  describe 'Create A Vendor' do
+    it "creates a new vendor, GOOD data 201 status,  create - /api/v0/vendors" do
+      vendor_params = ({
+                      name: 'Murder Stuffs',
+                      description: 'Sppoky things',
+                      contact_name: 'Sam T',
+                      contact_phone: '1-800-522-1032',
+                      credit_accepted: true
+                    })
+      headers = {"CONTENT_TYPE" => "application/json"}
     
-    expect(data[:errors]).to be_a(Array)
-    expect(data[:errors].first[:status]).to eq("404")
-    expect(data[:errors].first[:title]).to eq("Couldn't find Vendor with 'id'=1")
+      post "/api/v0/vendors", headers: headers, params: JSON.generate(vendor: vendor_params)
+      created_vendor = Vendor.last
+
+      expect(response).to be_successful
+      expect(response.status).to eq(201)
+
+      expect(created_vendor.name).to eq(vendor_params[:name])
+      expect(created_vendor.description).to eq(vendor_params[:description])
+      expect(created_vendor.contact_name).to eq(vendor_params[:contact_name])
+      expect(created_vendor.contact_phone).to eq(vendor_params[:contact_phone])
+      expect(created_vendor.credit_accepted).to eq(vendor_params[:credit_accepted])
+    end
+
+    it "creates a new vendor, MISSING name 400 status,  create - /api/v0/vendors, SAD PATH" do
+      vendor_params = ({
+                      description: 'Sppoky things',
+                      contact_name: 'Sam T',
+                      contact_phone: '1-800-522-1032',
+                      credit_accepted: true
+                    })
+      headers = {"CONTENT_TYPE" => "application/json"}
+
+      post "/api/v0/vendors", headers: headers, params: JSON.generate(vendor: vendor_params)
+      expect(response.status).to eq(400)
+      data = JSON.parse(response.body, symbolize_names: true)
+
+      expect(data[:errors]).to be_a(Array)
+      expect(data[:errors].first[:status]).to eq("400")
+      expect(data[:errors].first[:title]).to eq("Validation failed: Name can't be blank")
+    end
+
+    it "creates a new vendor, MISSING description 400 status,  create - /api/v0/vendors, SAD PATH" do
+      vendor_params = ({
+                      name: 'Murder Stuff',
+                      contact_name: 'Sam T',
+                      contact_phone: '1-800-522-1032',
+                      credit_accepted: true
+                    })
+      headers = {"CONTENT_TYPE" => "application/json"}
+
+      post "/api/v0/vendors", headers: headers, params: JSON.generate(vendor: vendor_params)
+      expect(response.status).to eq(400)
+      data = JSON.parse(response.body, symbolize_names: true)
+
+      expect(data[:errors]).to be_a(Array)
+      expect(data[:errors].first[:status]).to eq("400")
+      expect(data[:errors].first[:title]).to eq("Validation failed: Description can't be blank")
+    end
+
+    it "creates a new vendor, MISSING contact_name 400 status,  create - /api/v0/vendors, SAD PATH" do
+      vendor_params = ({
+                      name: 'Murder Stuff',
+                      description: 'Spooky Things',
+                      contact_phone: '1-800-522-1032',
+                      credit_accepted: true
+                    })
+      headers = {"CONTENT_TYPE" => "application/json"}
+
+      post "/api/v0/vendors", headers: headers, params: JSON.generate(vendor: vendor_params)
+      expect(response.status).to eq(400)
+      data = JSON.parse(response.body, symbolize_names: true)
+
+      expect(data[:errors]).to be_a(Array)
+      expect(data[:errors].first[:status]).to eq("400")
+      expect(data[:errors].first[:title]).to eq("Validation failed: Contact name can't be blank")
+    end
+
+    it "creates a new vendor, MISSING contact_phone 400 status,  create - /api/v0/vendors, SAD PATH" do
+      vendor_params = ({
+                      name: 'Murder Stuff',
+                      description: 'Spooky Things',
+                      contact_name: 'Sam T',
+                      credit_accepted: true
+                    })
+      headers = {"CONTENT_TYPE" => "application/json"}
+
+      post "/api/v0/vendors", headers: headers, params: JSON.generate(vendor: vendor_params)
+      expect(response.status).to eq(400)
+      data = JSON.parse(response.body, symbolize_names: true)
+
+      expect(data[:errors]).to be_a(Array)
+      expect(data[:errors].first[:status]).to eq("400")
+      expect(data[:errors].first[:title]).to eq("Validation failed: Contact phone can't be blank")
+    end
+
+    it "creates a new vendor, MISSING credit_accepted 400 status,  create - /api/v0/vendors, SAD PATH" do
+      vendor_params = ({
+                      name: 'Murder Stuff',
+                      description: 'Spooky Things',
+                      contact_name: 'Sam T',
+                      contact_phone: '1-800-522-1032',
+                    })
+      headers = {"CONTENT_TYPE" => "application/json"}
+
+      post "/api/v0/vendors", headers: headers, params: JSON.generate(vendor: vendor_params)
+      expect(response.status).to eq(400)
+      data = JSON.parse(response.body, symbolize_names: true)
+
+      expect(data[:errors]).to be_a(Array)
+      expect(data[:errors].first[:status]).to eq("400")
+      expect(data[:errors].first[:title]).to eq("Validation failed: Credit accepted can't be blank")
+    end
   end
 
-  it "creates a new vendor, GOOD data 201 status,  create - /api/v0/vendors" do
-    vendor_params = ({
-                    name: 'Murder Stuffs',
-                    description: 'Sppoky things',
-                    contact_name: 'Sam T',
-                    contact_phone: '1-800-522-1032',
-                    credit_accepted: true
-                  })
-    headers = {"CONTENT_TYPE" => "application/json"}
-  
-    post "/api/v0/vendors", headers: headers, params: JSON.generate(vendor: vendor_params)
-    created_vendor = Vendor.last
-
-    expect(response).to be_successful
-    expect(response.status).to eq(201)
-
-    expect(created_vendor.name).to eq(vendor_params[:name])
-    expect(created_vendor.description).to eq(vendor_params[:description])
-    expect(created_vendor.contact_name).to eq(vendor_params[:contact_name])
-    expect(created_vendor.contact_phone).to eq(vendor_params[:contact_phone])
-    expect(created_vendor.credit_accepted).to eq(vendor_params[:credit_accepted])
-  end
-
-  it "creates a new vendor, MISSING name 400 status,  create - /api/v0/vendors, SAD PATH" do
-    vendor_params = ({
-                    description: 'Sppoky things',
-                    contact_name: 'Sam T',
-                    contact_phone: '1-800-522-1032',
-                    credit_accepted: true
-                  })
-    headers = {"CONTENT_TYPE" => "application/json"}
-
-    post "/api/v0/vendors", headers: headers, params: JSON.generate(vendor: vendor_params)
-    expect(response.status).to eq(400)
-    data = JSON.parse(response.body, symbolize_names: true)
-
-    expect(data[:errors]).to be_a(Array)
-    expect(data[:errors].first[:status]).to eq("400")
-    expect(data[:errors].first[:title]).to eq("Validation failed: Name can't be blank")
-  end
-
-  it "creates a new vendor, MISSING description 400 status,  create - /api/v0/vendors, SAD PATH" do
-    vendor_params = ({
-                    name: 'Murder Stuff',
-                    contact_name: 'Sam T',
-                    contact_phone: '1-800-522-1032',
-                    credit_accepted: true
-                  })
-    headers = {"CONTENT_TYPE" => "application/json"}
-
-    post "/api/v0/vendors", headers: headers, params: JSON.generate(vendor: vendor_params)
-    expect(response.status).to eq(400)
-    data = JSON.parse(response.body, symbolize_names: true)
-
-    expect(data[:errors]).to be_a(Array)
-    expect(data[:errors].first[:status]).to eq("400")
-    expect(data[:errors].first[:title]).to eq("Validation failed: Description can't be blank")
-  end
-
-  it "creates a new vendor, MISSING contact_name 400 status,  create - /api/v0/vendors, SAD PATH" do
-    vendor_params = ({
-                    name: 'Murder Stuff',
-                    description: 'Spooky Things',
-                    contact_phone: '1-800-522-1032',
-                    credit_accepted: true
-                  })
-    headers = {"CONTENT_TYPE" => "application/json"}
-
-    post "/api/v0/vendors", headers: headers, params: JSON.generate(vendor: vendor_params)
-    expect(response.status).to eq(400)
-    data = JSON.parse(response.body, symbolize_names: true)
-
-    expect(data[:errors]).to be_a(Array)
-    expect(data[:errors].first[:status]).to eq("400")
-    expect(data[:errors].first[:title]).to eq("Validation failed: Contact name can't be blank")
-  end
-
-  it "creates a new vendor, MISSING contact_phone 400 status,  create - /api/v0/vendors, SAD PATH" do
-    vendor_params = ({
-                    name: 'Murder Stuff',
-                    description: 'Spooky Things',
-                    contact_name: 'Sam T',
-                    credit_accepted: true
-                  })
-    headers = {"CONTENT_TYPE" => "application/json"}
-
-    post "/api/v0/vendors", headers: headers, params: JSON.generate(vendor: vendor_params)
-    expect(response.status).to eq(400)
-    data = JSON.parse(response.body, symbolize_names: true)
-
-    expect(data[:errors]).to be_a(Array)
-    expect(data[:errors].first[:status]).to eq("400")
-    expect(data[:errors].first[:title]).to eq("Validation failed: Contact phone can't be blank")
-  end
-
-  it "creates a new vendor, MISSING credit_accepted 400 status,  create - /api/v0/vendors, SAD PATH" do
-    vendor_params = ({
-                    name: 'Murder Stuff',
-                    description: 'Spooky Things',
-                    contact_name: 'Sam T',
-                    contact_phone: '1-800-522-1032',
-                  })
-    headers = {"CONTENT_TYPE" => "application/json"}
-
-    post "/api/v0/vendors", headers: headers, params: JSON.generate(vendor: vendor_params)
-    expect(response.status).to eq(400)
-    data = JSON.parse(response.body, symbolize_names: true)
-
-    expect(data[:errors]).to be_a(Array)
-    expect(data[:errors].first[:status]).to eq("400")
-    expect(data[:errors].first[:title]).to eq("Validation failed: Credit accepted can't be blank")
-  end
-
-  it "can destroy an vendor, by id, successful 204 status, delete - /api/v0/vendors/:id" do
-    vendor = create(:vendor)
-    market = create(:market)
-    market_vendor = create(:market_vendor, market: market, vendor: vendor)
-  
-    expect{ delete "/api/v0/vendors/#{vendor.id}" }.to change(Vendor, :count).by(-1)
-    expect(response.status).to eq(204)
-    expect{Vendor.find(vendor.id)}.to raise_error(ActiveRecord::RecordNotFound)
-    expect{MarketVendor.find(market_vendor.id)}.to raise_error(ActiveRecord::RecordNotFound)
-  end
-
-  it "can destroy an vendor, by BAD id, 404 status, delete - /api/v0/vendors/:id, SAD path" do
-    vendor = create(:vendor)
-    market = create(:market)
-    market_vendor = create(:market_vendor, market: market, vendor: vendor)
-  
-    expect{ delete "/api/v0/vendors/1" }.to change(Vendor, :count).by(0)
-    expect(response.status).to eq(404)
-
-    data = JSON.parse(response.body, symbolize_names: true)
+  describe 'Update a Vendor' do
+    it "creates a new vendor, GOOD data 201 status,  create - /api/v0/vendors" do
+      vendor_params = ({
+                      name: 'Murder Stuffs',
+                      description: 'Sppoky things',
+                      contact_name: 'Sam T',
+                      contact_phone: '1-800-522-1032',
+                      credit_accepted: true
+                    })
+      headers = {"CONTENT_TYPE" => "application/json"}
     
-    expect(data[:errors]).to be_a(Array)
-    expect(data[:errors].first[:status]).to eq("404")
-    expect(data[:errors].first[:title]).to eq("Couldn't find Vendor with 'id'=1")
+      post "/api/v0/vendors", headers: headers, params: JSON.generate(vendor: vendor_params)
+      created_vendor = Vendor.last
+
+      expect(response).to be_successful
+      expect(response.status).to eq(201)
+
+      expect(created_vendor.name).to eq(vendor_params[:name])
+      expect(created_vendor.description).to eq(vendor_params[:description])
+      expect(created_vendor.contact_name).to eq(vendor_params[:contact_name])
+      expect(created_vendor.contact_phone).to eq(vendor_params[:contact_phone])
+      expect(created_vendor.credit_accepted).to eq(vendor_params[:credit_accepted])
+    end
+  end
+
+  describe 'Delete a Vendor' do
+    it "can destroy an vendor, by id, successful 204 status, delete - /api/v0/vendors/:id" do
+      vendor = create(:vendor)
+      market = create(:market)
+      market_vendor = create(:market_vendor, market: market, vendor: vendor)
+    
+      expect{ delete "/api/v0/vendors/#{vendor.id}" }.to change(Vendor, :count).by(-1)
+      expect(response.status).to eq(204)
+      expect{Vendor.find(vendor.id)}.to raise_error(ActiveRecord::RecordNotFound)
+      expect{MarketVendor.find(market_vendor.id)}.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it "can destroy an vendor, by BAD id, 404 status, delete - /api/v0/vendors/:id, SAD path" do
+      vendor = create(:vendor)
+      market = create(:market)
+      market_vendor = create(:market_vendor, market: market, vendor: vendor)
+    
+      expect{ delete "/api/v0/vendors/1" }.to change(Vendor, :count).by(0)
+      expect(response.status).to eq(404)
+
+      data = JSON.parse(response.body, symbolize_names: true)
+      
+      expect(data[:errors]).to be_a(Array)
+      expect(data[:errors].first[:status]).to eq("404")
+      expect(data[:errors].first[:title]).to eq("Couldn't find Vendor with 'id'=1")
+    end
   end
 
 end

--- a/spec/requests/api/v0/vendors_request_spec.rb
+++ b/spec/requests/api/v0/vendors_request_spec.rb
@@ -157,7 +157,7 @@ describe 'Vendors API', type: :request do
   end
 
   describe 'Update a Vendor' do
-    it "updates a current vendor, GOOD all data 201 status, update - /api/v0/vendors/:id" do
+    it "updates a current vendor, GOOD all data 200 status, update - /api/v0/vendors/:id" do
       vendor_params = ({
                       name: 'Happy Stuffs',
                       description: 'Cute things',
@@ -177,7 +177,7 @@ describe 'Vendors API', type: :request do
       patch "/api/v0/vendors/#{vendor.id}", headers: headers, params: JSON.generate(vendor: vendor_params)
 
       expect(response).to be_successful
-      expect(response.status).to eq(201)
+      expect(response.status).to eq(200)
 
       expect(vendor.name).to eq(vendor_params[:name])
       expect(vendor.description).to eq(vendor_params[:description])
@@ -186,7 +186,7 @@ describe 'Vendors API', type: :request do
       expect(vendor.credit_accepted).to eq(vendor_params[:credit_accepted])
     end
 
-    it "updates a current vendor, GOOD some data 201 status, update - /api/v0/vendors/:id" do
+    it "updates a current vendor, GOOD some data 200 status, update - /api/v0/vendors/:id" do
       vendor_params = ({
                       name: 'Happy Stuffs',
                       contact_phone: '1-888-522-1032'
@@ -200,7 +200,7 @@ describe 'Vendors API', type: :request do
       patch "/api/v0/vendors/#{vendor.id}", headers: headers, params: JSON.generate(vendor: vendor_params)
 
       expect(response).to be_successful
-      expect(response.status).to eq(201)
+      expect(response.status).to eq(200)
 
       expect(vendor.name).to eq(vendor_params[:name])
       expect(vendor.contact_phone).to eq(vendor_params[:contact_phone])

--- a/spec/requests/api/v0/vendors_request_spec.rb
+++ b/spec/requests/api/v0/vendors_request_spec.rb
@@ -166,7 +166,8 @@ describe 'Vendors API', type: :request do
                       credit_accepted: false
                     })
       headers = {"CONTENT_TYPE" => "application/json"}
-      vendor = create(:vendor)
+      vendor = create(:vendor, credit_accepted: true)
+      vendor_id = vendor.id
 
       expect(vendor.name).to_not eq(vendor_params[:name])
       expect(vendor.description).to_not eq(vendor_params[:description])
@@ -178,6 +179,8 @@ describe 'Vendors API', type: :request do
 
       expect(response).to be_successful
       expect(response.status).to eq(200)
+
+      vendor = Vendor.find(vendor_id) # Persistence issue, need to reassign variable after update
 
       expect(vendor.name).to eq(vendor_params[:name])
       expect(vendor.description).to eq(vendor_params[:description])
@@ -193,6 +196,7 @@ describe 'Vendors API', type: :request do
                     })
       headers = {"CONTENT_TYPE" => "application/json"}
       vendor = create(:vendor)
+      vendor_id = vendor.id
 
       expect(vendor.name).to_not eq(vendor_params[:name])
       expect(vendor.contact_phone).to_not eq(vendor_params[:contact_phone])
@@ -201,6 +205,8 @@ describe 'Vendors API', type: :request do
 
       expect(response).to be_successful
       expect(response.status).to eq(200)
+
+      vendor = Vendor.find(vendor_id) # Persistence issue, need to reassign variable after update
 
       expect(vendor.name).to eq(vendor_params[:name])
       expect(vendor.contact_phone).to eq(vendor_params[:contact_phone])
@@ -234,7 +240,7 @@ describe 'Vendors API', type: :request do
 
       patch "/api/v0/vendors/#{vendor.id}", headers: headers, params: JSON.generate(vendor: vendor_params)
 
-      expect(response).to be_successful
+      expect(response).to_not be_successful
       expect(response.status).to eq(400)
       data = JSON.parse(response.body, symbolize_names: true)
 
@@ -252,7 +258,7 @@ describe 'Vendors API', type: :request do
 
       patch "/api/v0/vendors/#{vendor.id}", headers: headers, params: JSON.generate(vendor: vendor_params)
 
-      expect(response).to be_successful
+      expect(response).to_not be_successful
       expect(response.status).to eq(400)
       data = JSON.parse(response.body, symbolize_names: true)
 
@@ -270,7 +276,7 @@ describe 'Vendors API', type: :request do
 
       patch "/api/v0/vendors/#{vendor.id}", headers: headers, params: JSON.generate(vendor: vendor_params)
 
-      expect(response).to be_successful
+      expect(response).to_not be_successful
       expect(response.status).to eq(400)
       data = JSON.parse(response.body, symbolize_names: true)
 
@@ -288,7 +294,7 @@ describe 'Vendors API', type: :request do
 
       patch "/api/v0/vendors/#{vendor.id}", headers: headers, params: JSON.generate(vendor: vendor_params)
 
-      expect(response).to be_successful
+      expect(response).to_not be_successful
       expect(response.status).to eq(400)
       data = JSON.parse(response.body, symbolize_names: true)
 
@@ -306,7 +312,7 @@ describe 'Vendors API', type: :request do
 
       patch "/api/v0/vendors/#{vendor.id}", headers: headers, params: JSON.generate(vendor: vendor_params)
 
-      expect(response).to be_successful
+      expect(response).to_not be_successful
       expect(response.status).to eq(400)
       data = JSON.parse(response.body, symbolize_names: true)
 

--- a/spec/requests/api/v0/vendors_request_spec.rb
+++ b/spec/requests/api/v0/vendors_request_spec.rb
@@ -42,7 +42,7 @@ describe 'Vendors API', type: :request do
   end
 
   describe 'Create A Vendor' do
-    it "creates a new vendor, GOOD data 201 status,  create - /api/v0/vendors" do
+    it "creates a new vendor, GOOD data 201 status, create - /api/v0/vendors" do
       vendor_params = ({
                       name: 'Murder Stuffs',
                       description: 'Sppoky things',
@@ -65,7 +65,7 @@ describe 'Vendors API', type: :request do
       expect(created_vendor.credit_accepted).to eq(vendor_params[:credit_accepted])
     end
 
-    it "creates a new vendor, MISSING name 400 status,  create - /api/v0/vendors, SAD PATH" do
+    it "creates a new vendor, MISSING name 400 status, create - /api/v0/vendors, SAD PATH" do
       vendor_params = ({
                       description: 'Sppoky things',
                       contact_name: 'Sam T',
@@ -83,7 +83,7 @@ describe 'Vendors API', type: :request do
       expect(data[:errors].first[:title]).to eq("Validation failed: Name can't be blank")
     end
 
-    it "creates a new vendor, MISSING description 400 status,  create - /api/v0/vendors, SAD PATH" do
+    it "creates a new vendor, MISSING description 400 status, create - /api/v0/vendors, SAD PATH" do
       vendor_params = ({
                       name: 'Murder Stuff',
                       contact_name: 'Sam T',
@@ -101,7 +101,7 @@ describe 'Vendors API', type: :request do
       expect(data[:errors].first[:title]).to eq("Validation failed: Description can't be blank")
     end
 
-    it "creates a new vendor, MISSING contact_name 400 status,  create - /api/v0/vendors, SAD PATH" do
+    it "creates a new vendor, MISSING contact_name 400 status, create - /api/v0/vendors, SAD PATH" do
       vendor_params = ({
                       name: 'Murder Stuff',
                       description: 'Spooky Things',
@@ -119,7 +119,7 @@ describe 'Vendors API', type: :request do
       expect(data[:errors].first[:title]).to eq("Validation failed: Contact name can't be blank")
     end
 
-    it "creates a new vendor, MISSING contact_phone 400 status,  create - /api/v0/vendors, SAD PATH" do
+    it "creates a new vendor, MISSING contact_phone 400 status, create - /api/v0/vendors, SAD PATH" do
       vendor_params = ({
                       name: 'Murder Stuff',
                       description: 'Spooky Things',
@@ -137,7 +137,7 @@ describe 'Vendors API', type: :request do
       expect(data[:errors].first[:title]).to eq("Validation failed: Contact phone can't be blank")
     end
 
-    it "creates a new vendor, MISSING credit_accepted 400 status,  create - /api/v0/vendors, SAD PATH" do
+    it "creates a new vendor, MISSING credit_accepted 400 status, create - /api/v0/vendors, SAD PATH" do
       vendor_params = ({
                       name: 'Murder Stuff',
                       description: 'Spooky Things',
@@ -157,27 +157,162 @@ describe 'Vendors API', type: :request do
   end
 
   describe 'Update a Vendor' do
-    it "creates a new vendor, GOOD data 201 status,  create - /api/v0/vendors" do
+    it "updates a current vendor, GOOD all data 201 status, update - /api/v0/vendors/:id" do
       vendor_params = ({
-                      name: 'Murder Stuffs',
-                      description: 'Sppoky things',
-                      contact_name: 'Sam T',
-                      contact_phone: '1-800-522-1032',
-                      credit_accepted: true
+                      name: 'Happy Stuffs',
+                      description: 'Cute things',
+                      contact_name: 'Sam Tran',
+                      contact_phone: '1-888-522-1032',
+                      credit_accepted: false
                     })
       headers = {"CONTENT_TYPE" => "application/json"}
-    
-      post "/api/v0/vendors", headers: headers, params: JSON.generate(vendor: vendor_params)
-      created_vendor = Vendor.last
+      vendor = create(:vendor)
+
+      expect(vendor.name).to_not eq(vendor_params[:name])
+      expect(vendor.description).to_not eq(vendor_params[:description])
+      expect(vendor.contact_name).to_not eq(vendor_params[:contact_name])
+      expect(vendor.contact_phone).to_not eq(vendor_params[:contact_phone])
+      expect(vendor.credit_accepted).to_not eq(vendor_params[:credit_accepted])
+
+      patch "/api/v0/vendors/#{vendor.id}", headers: headers, params: JSON.generate(vendor: vendor_params)
 
       expect(response).to be_successful
       expect(response.status).to eq(201)
 
-      expect(created_vendor.name).to eq(vendor_params[:name])
-      expect(created_vendor.description).to eq(vendor_params[:description])
-      expect(created_vendor.contact_name).to eq(vendor_params[:contact_name])
-      expect(created_vendor.contact_phone).to eq(vendor_params[:contact_phone])
-      expect(created_vendor.credit_accepted).to eq(vendor_params[:credit_accepted])
+      expect(vendor.name).to eq(vendor_params[:name])
+      expect(vendor.description).to eq(vendor_params[:description])
+      expect(vendor.contact_name).to eq(vendor_params[:contact_name])
+      expect(vendor.contact_phone).to eq(vendor_params[:contact_phone])
+      expect(vendor.credit_accepted).to eq(vendor_params[:credit_accepted])
+    end
+
+    it "updates a current vendor, GOOD some data 201 status, update - /api/v0/vendors/:id" do
+      vendor_params = ({
+                      name: 'Happy Stuffs',
+                      contact_phone: '1-888-522-1032'
+                    })
+      headers = {"CONTENT_TYPE" => "application/json"}
+      vendor = create(:vendor)
+
+      expect(vendor.name).to_not eq(vendor_params[:name])
+      expect(vendor.contact_phone).to_not eq(vendor_params[:contact_phone])
+
+      patch "/api/v0/vendors/#{vendor.id}", headers: headers, params: JSON.generate(vendor: vendor_params)
+
+      expect(response).to be_successful
+      expect(response.status).to eq(201)
+
+      expect(vendor.name).to eq(vendor_params[:name])
+      expect(vendor.contact_phone).to eq(vendor_params[:contact_phone])
+    end
+
+    it "updates a current vendor, BAD vendor ID, 404 status, update - /api/v0/vendors/:id" do
+      vendor_params = ({
+                      name: 'Happy Stuffs',
+                      contact_phone: '1-888-522-1032'
+                    })
+      headers = {"CONTENT_TYPE" => "application/json"}
+
+      patch "/api/v0/vendors/1", headers: headers, params: JSON.generate(vendor: vendor_params)
+
+      expect(response).to_not be_successful
+      expect(response.status).to eq(404)
+
+      data = JSON.parse(response.body, symbolize_names: true)
+      
+      expect(data[:errors]).to be_a(Array)
+      expect(data[:errors].first[:status]).to eq("404")
+      expect(data[:errors].first[:title]).to eq("Couldn't find Vendor with 'id'=1")
+    end
+
+    it "updates a current vendor, BAD nil name data 400 status, update - /api/v0/vendors/:id" do
+      vendor_params = ({
+                      name: nil,
+                    })
+      headers = {"CONTENT_TYPE" => "application/json"}
+      vendor = create(:vendor)
+
+      patch "/api/v0/vendors/#{vendor.id}", headers: headers, params: JSON.generate(vendor: vendor_params)
+
+      expect(response).to be_successful
+      expect(response.status).to eq(400)
+      data = JSON.parse(response.body, symbolize_names: true)
+
+      expect(data[:errors]).to be_a(Array)
+      expect(data[:errors].first[:status]).to eq("400")
+      expect(data[:errors].first[:title]).to eq("Validation failed: Name can't be blank")
+    end
+
+    it "updates a current vendor, BAD nil description data 400 status, update - /api/v0/vendors/:id" do
+      vendor_params = ({
+                      description: nil
+                    })
+      headers = {"CONTENT_TYPE" => "application/json"}
+      vendor = create(:vendor)
+
+      patch "/api/v0/vendors/#{vendor.id}", headers: headers, params: JSON.generate(vendor: vendor_params)
+
+      expect(response).to be_successful
+      expect(response.status).to eq(400)
+      data = JSON.parse(response.body, symbolize_names: true)
+
+      expect(data[:errors]).to be_a(Array)
+      expect(data[:errors].first[:status]).to eq("400")
+      expect(data[:errors].first[:title]).to eq("Validation failed: Description can't be blank")
+    end
+
+    it "updates a current vendor, BAD nil contact_phone data 400 status, update - /api/v0/vendors/:id" do
+      vendor_params = ({
+                      contact_phone: nil
+                    })
+      headers = {"CONTENT_TYPE" => "application/json"}
+      vendor = create(:vendor)
+
+      patch "/api/v0/vendors/#{vendor.id}", headers: headers, params: JSON.generate(vendor: vendor_params)
+
+      expect(response).to be_successful
+      expect(response.status).to eq(400)
+      data = JSON.parse(response.body, symbolize_names: true)
+
+      expect(data[:errors]).to be_a(Array)
+      expect(data[:errors].first[:status]).to eq("400")
+      expect(data[:errors].first[:title]).to eq("Validation failed: Contact phone can't be blank")
+    end
+
+    it "updates a current vendor, BAD nil contact_name data 400 status, update - /api/v0/vendors/:id" do
+      vendor_params = ({
+                      contact_name: nil
+                    })
+      headers = {"CONTENT_TYPE" => "application/json"}
+      vendor = create(:vendor)
+
+      patch "/api/v0/vendors/#{vendor.id}", headers: headers, params: JSON.generate(vendor: vendor_params)
+
+      expect(response).to be_successful
+      expect(response.status).to eq(400)
+      data = JSON.parse(response.body, symbolize_names: true)
+
+      expect(data[:errors]).to be_a(Array)
+      expect(data[:errors].first[:status]).to eq("400")
+      expect(data[:errors].first[:title]).to eq("Validation failed: Contact name can't be blank")
+    end
+
+    it "updates a current vendor, BAD nil credit_accepted data 400 status, update - /api/v0/vendors/:id" do
+      vendor_params = ({
+                      credit_accepted: ''
+                    })
+      headers = {"CONTENT_TYPE" => "application/json"}
+      vendor = create(:vendor)
+
+      patch "/api/v0/vendors/#{vendor.id}", headers: headers, params: JSON.generate(vendor: vendor_params)
+
+      expect(response).to be_successful
+      expect(response.status).to eq(400)
+      data = JSON.parse(response.body, symbolize_names: true)
+
+      expect(data[:errors]).to be_a(Array)
+      expect(data[:errors].first[:status]).to eq("400")
+      expect(data[:errors].first[:title]).to eq("Validation failed: Credit accepted can't be blank")
     end
   end
 
@@ -208,5 +343,4 @@ describe 'Vendors API', type: :request do
       expect(data[:errors].first[:title]).to eq("Couldn't find Vendor with 'id'=1")
     end
   end
-
 end


### PR DESCRIPTION
Add endpoint `PATCH /api/v0/vendors/:id`

1. This endpoint should follow the pattern of PATCH /api/v0/vendors/:id, and can pass any number and combination of attribtues to be updated (name, description, contact_name, contact_phone, and credit_accepted) as JSON in the body of the request. (In postman, navigate to Body tab, select raw and change the format to JSON instead of Text)
2. This endpoint should update an existing vendor with any parameters sent in via the body. 200 response
3. If someone were to try to update a vendor resource to have a nil or empty attribute, a proper 400-level status code as well as a descriptive error message should be sent back in the response.
4. A successful response will return the newly updated vendor resource.

Notes
REMEMBER IN FUTURE, sometimes it is a test issue, variable persistence issues, variable did up update along with update  request, had to reassign variable AFTER.