### PR TITLE
9 DELETE MarketVendor

### DIFF
--- a/app/controllers/api/v0/market_vendors_controller.rb
+++ b/app/controllers/api/v0/market_vendors_controller.rb
@@ -26,6 +26,18 @@ class Api::V0::MarketVendorsController < ApplicationController
     end
   end
 
+  def destroy
+    market_vendor = MarketVendor.find_by(market_vendor_params)
+    market_id = market_vendor_params[:market_id]
+    vendor_id = market_vendor_params[:vendor_id]
+    
+    if market_vendor.nil?
+      delete_error_response(market_id, vendor_id)
+    else
+      render json: MarketVendor.delete(market_vendor), status: 204
+    end
+  end
+
   private
 
   def market_vendor_params
@@ -45,5 +57,10 @@ class Api::V0::MarketVendorsController < ApplicationController
   def duplicate_id_error_response(market_id, vendor_id)
     render json: ErrorSerializer.new(ErrorMessage.new("Validation failed: Market vendor asociation between market with market_id=#{market_id} and vendor_id=#{vendor_id} already exists", 422))
     .serialize_json, status: :unprocessable_entity
+  end
+
+  def delete_error_response(market_id, vendor_id)
+    render json: ErrorSerializer.new(ErrorMessage.new("Validation failed: Market vendor asociation between market with market_id=#{market_id} and vendor_id=#{vendor_id} already exists", 404))
+    .serialize_json, status: 404
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
         resources :vendors, only: [:show, :create, :update, :destroy]
 
         resources :market_vendors, only: [:create]
+        delete '/market_vendors', to: 'market_vendors#destroy'
       end
     end
   end

--- a/spec/requests/api/v0/market_vendors_request_spec.rb
+++ b/spec/requests/api/v0/market_vendors_request_spec.rb
@@ -216,7 +216,7 @@ describe 'Market Vendors API', type: :request do
   end
 
   describe 'Delete a MarketVendor' do
-    xit 'creates new market and a vendor association, GOOD data, 201 status, DELETE /api/v0/market_vendors' do
+    it 'deletes, GOOD data, 201 status, DELETE /api/v0/market_vendors' do
       market = create(:market)
       vendor = create(:vendor)
       create(:market_vendor, market: market, vendor: vendor)
@@ -233,6 +233,27 @@ describe 'Market Vendors API', type: :request do
       expect(response).to be_successful
       expect(response.status).to eq(204)
       expect(MarketVendor.count).to eq(0)
+    end
+
+    it 'deletes, GOOD data, 201 status, DELETE /api/v0/market_vendors' do
+      market = create(:market)
+      vendor = create(:vendor)
+      market_vendor_params = ({
+                      market_id: market.id,
+                      vendor_id: vendor.id
+                    })
+      headers = {'CONTENT_TYPE' => 'application/json'}
+
+      delete '/api/v0/market_vendors', headers: headers, params: JSON.generate(market_vendor: market_vendor_params)
+
+      expect(response).to_not be_successful
+      expect(response.status).to eq(404)
+
+      data = JSON.parse(response.body, symbolize_names: true)
+
+      expect(data[:errors]).to be_a(Array)
+      expect(data[:errors].first[:status]).to eq('404')
+      expect(data[:errors].first[:title]).to eq("Validation failed: Market vendor asociation between market with market_id=#{market.id} and vendor_id=#{vendor.id} already exists")
     end
   end
 end


### PR DESCRIPTION
Add endpoint `DELETE /api/v0/market_vendors`

1. This endpoint should follow the pattern of DELETE /api/v0/market_vendors, and it should destroy an existing association between a market and a vendor (so that a vendor no longer is listed at a certain market).
2. The market_id and the vendor_id should be passed in via the body.
When a MarketVendor resource can be found with the passed in vendor_id and market_id, that resource should be destroyed, and a response will be sent back with a 204 status, with nothing returned in the body of the request.
3. After implementing the happy path for this endpoint, run it, and check that when you call GET /api/v0/vendors/:id/markets for the vendor in which you just deleted an association to a market, that you don’t see the recently removed market listed.
4. If a MarketVendor resource can NOT be found with the passed in vendor_id and market_id, a 404 status code as well as a descriptive message should be sent back with the response.