### PR TITLE
10 SEARCH Markets by State/City/Name

### DIFF
--- a/app/controllers/api/v0/market_vendors_controller.rb
+++ b/app/controllers/api/v0/market_vendors_controller.rb
@@ -24,6 +24,18 @@ class Api::V0::MarketVendorsController < ApplicationController
         not_found_response(exception)
       end
     end
+
+      # THIS DID NOT WORK :(
+      # begin
+      #   market_vendor = MarketVendor.create!(market_id: market_vendor_params[:market_id], vendor_id: market_vendor_params[:vendor_id])
+      #   render json: MarketVendorSerializer.new(market_vendor), status: :created
+      # rescue ActionController::ParameterMissing => exception
+      #   param_missing_error_response(exception)
+      # rescue ActiveRecord::RecordInvalid => exception
+      #   validation_error_response(exception)
+      # rescue ActiveRecord::RecordNotFound => exception
+      #   not_found_response(exception)
+      # end
   end
 
   def destroy

--- a/app/controllers/api/v0/markets/search_controller.rb
+++ b/app/controllers/api/v0/markets/search_controller.rb
@@ -1,0 +1,18 @@
+class Api::V0::Markets::SearchController < ApplicationController
+  def markets
+    if params[:city] && !params[:state]
+      params_combination_validator_error
+    else
+      markets = Market.search(params[:state], params[:city], params[:name])
+      # render json: MarketSerializer.new(markets), status: 200
+      render json: SearchSerializer.format_market_search(markets), status: 200
+    end
+  end
+
+  private
+
+  def params_combination_validator_error
+    render json: ErrorSerializer.new(ErrorMessage.new("Invalid params combination, needs state included, or just name", 422))
+      .serialize_json, status: 422
+  end
+end

--- a/app/controllers/api/v0/markets/search_controller.rb
+++ b/app/controllers/api/v0/markets/search_controller.rb
@@ -4,7 +4,6 @@ class Api::V0::Markets::SearchController < ApplicationController
       params_combination_validator_error
     else
       markets = Market.search(params[:state], params[:city], params[:name])
-      # render json: MarketSerializer.new(markets), status: 200
       render json: SearchSerializer.format_market_search(markets), status: 200
     end
   end

--- a/app/models/market.rb
+++ b/app/models/market.rb
@@ -7,4 +7,18 @@ class Market < ApplicationRecord
   def get_vendor_count
     self.vendors.count
   end
+
+  def self.search(state, city, name)
+    # results = all
+
+    # results = results.where('LOWER(state) = ?', state.downcase) if state.present?
+    # results = results.where(city: city) if city.present?
+    # results = results.where('LOWER(name) LIKE ?', "%#{name.downcase}%") if name.present?
+  
+    # results
+
+        results = results.where('LOWER(state) = ?', state.downcase) if state.present?
+    results = results.where(city: city) if city.present?
+    results = results.where('LOWER(name) LIKE ?', "%#{name.downcase}%") if name.present?
+  end
 end

--- a/app/models/market.rb
+++ b/app/models/market.rb
@@ -9,16 +9,6 @@ class Market < ApplicationRecord
   end
 
   def self.search(state, city, name)
-    # results = all
-
-    # results = results.where('LOWER(state) = ?', state.downcase) if state.present?
-    # results = results.where(city: city) if city.present?
-    # results = results.where('LOWER(name) LIKE ?', "%#{name.downcase}%") if name.present?
-  
-    # results
-
-        results = results.where('LOWER(state) = ?', state.downcase) if state.present?
-    results = results.where(city: city) if city.present?
-    results = results.where('LOWER(name) LIKE ?', "%#{name.downcase}%") if name.present?
+    Market.where("markets.city ILIKE '%#{city}%' and markets.state ILIKE '%#{state}%' and markets.name ilike '%#{name}%'")
   end
 end

--- a/app/serializers/search_serializer.rb
+++ b/app/serializers/search_serializer.rb
@@ -1,0 +1,23 @@
+class SearchSerializer
+  def self.format_market_search(markets)
+    {
+      data: markets.map do |market|
+        {
+          id: market.id,
+          type: 'market',
+          attributes: {
+            name: market.name,
+            street: market.street,
+            city: market.city,
+            county: market.county,
+            state: market.state,
+            zip: market.zip,
+            lat: market.lat,
+            lon: market.lon,
+            vendor_count: market.get_vendor_count
+          }
+        }
+      end
+    }
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   Rails.application.routes.draw do
     namespace :api do
       namespace :v0 do
+        get '/markets/search', to: 'markets/search#markets'
         resources :markets, only: [:index, :show] do
           resources :vendors, only: [:index], controller: 'market_vendors'
         end

--- a/spec/requests/api/v0/search_request_spec.rb
+++ b/spec/requests/api/v0/search_request_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+RSpec.describe 'Search by name, city, state', type: :request do
+  describe 'get /api/v0/markets/search' do
+    it 'returns a successful response, 200, with markets data' do
+      market = create(:market, state: 'Colorado', city: 'Denver', name: 'Farmers Market')
+      market_2 = create(:market, state: 'California', city: 'Denver', name: 'Farmers Market')
+
+      market_search_params = {
+        state: 'colorado'
+      }
+
+      get '/api/v0/markets/search', params: market_search_params
+
+      expect(response.status).to eq(200)
+      expect(response.body).to include(market.id.to_s)
+      expect(response.body).to include(market.name)
+      expect(response.body).to_not include(market_2.id.to_s)
+    end
+
+    it 'returns a successful response, 200, with markets data, when nothing is returned' do
+      market = create(:market, state: 'Colorado', city: 'Denver', name: 'Farmers Market')
+      market_2 = create(:market, state: 'California', city: 'Denver', name: 'Farmers Market')
+
+      market_search_params = {
+        state: "Arizona"
+      }
+
+      get '/api/v0/markets/search', params: market_search_params
+      data = JSON.parse(response.body, symbolize_names: true)
+
+      expect(response.status).to eq(200)
+      expect(data[:data]).to eq([])
+    end
+
+    it 'returns an error response with 422 status, invalid param combination 1' do
+      market = create(:market, state: 'Colorado', city: 'Denver', name: 'Farmers Market')
+      market_search_params = {
+        city: market.city
+      }
+
+      get '/api/v0/markets/search', params: market_search_params
+      expect(response.status).to eq(422)
+
+      data = JSON.parse(response.body, symbolize_names: true)
+
+      expect(data[:errors]).to be_a(Array)
+      expect(data[:errors].first[:status]).to eq('422')
+      expect(data[:errors].first[:title]).to eq("Invalid params combination, needs state included, or just name")
+    end
+
+    it 'returns an error response with 422 status, invalid param combination 2' do
+      market = create(:market, state: 'Colorado', city: 'Denver', name: 'Farmers Market')
+      market_search_params = {
+        city: market.city,
+        name: market.name
+      }
+
+      get '/api/v0/markets/search', params: market_search_params
+      expect(response.status).to eq(422)
+
+      data = JSON.parse(response.body, symbolize_names: true)
+
+      expect(data[:errors]).to be_a(Array)
+      expect(data[:errors].first[:status]).to eq('422')
+      expect(data[:errors].first[:title]).to eq("Invalid params combination, needs state included, or just name")
+    end
+  end
+end


### PR DESCRIPTION
Add endpoint `GET /api/v0/markets/search`

1. The endpoint should be in the pattern of GET /api/v0/markets/search, and can accept city, state, and name parameters.
2. The following combination of parameters can be sent in at any time:
- state
- state, city
- state, city, name
- state, name
- name
3. The following combination of parameters can NOT be sent in at any time:
- city
- city, name
4. If an invalid set of parameters are sent in, a proper error message should be sent back, along with a 422 status code.
5. In the event that valid parameters are sent in, and only one market is returned from the search, the data top level key should still point to an array holding that one market resource data.
6. Similar to above, in the event that valid parameters are sent in, and NO markets are returned, the data top level key should point to an empty array. And a status code of 200 should still be returned